### PR TITLE
chore(ceracoder): add .clang-format (LLVM style)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,90 @@
+Language:      Cpp
+BasedOnStyle:  LLVM
+AccessModifierOffset: -4
+# AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+# AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+# AllowAllArgumentsOnNextLine: true    # Requires clang-format v9 and higher
+# AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+# AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+# AllowShortIfStatementsOnASingleLine: false
+# AllowShortLoopsOnASingleLine: false
+# AlwaysBreakAfterDefinitionReturnType: None
+# AlwaysBreakAfterReturnType: None
+# AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+# BraceWrapping:   
+#   AfterClass:      false
+#   AfterControlStatement: false
+#   AfterEnum:       false
+#   AfterFunction:   false
+#   AfterNamespace:  false
+#   AfterObjCDeclaration: false
+#   AfterStruct:     false
+#   AfterUnion:      false
+#   BeforeCatch:     false
+#   BeforeElse:      false
+#   IndentBraces:    false
+# BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+# BreakInheritanceList: BeforeComma
+# BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+# BreakAfterJavaFieldAnnotations: false
+# BreakStringLiterals: true
+ColumnLimit:     120
+# CommentPragmas:  '^ IWYU pragma:'
+# ConstructorInitializerAllOnOneLineOrOnePerLine: false
+# ConstructorInitializerIndentWidth: 4
+# ContinuationIndentWidth: 4
+# Cpp11BracedListStyle: true
+# DerivePointerAlignment: false
+# DisableFormat:   false
+# ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+# ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+# IncludeIsMainRegex: '$'
+# IndentCaseLabels: false
+IndentWidth:     4
+# IndentWrappedFunctionNames: false
+# JavaScriptQuotes: Leave
+# JavaScriptWrapImports: true
+# KeepEmptyLinesAtTheStartOfBlocks: true
+# MacroBlockBegin: ''
+# MacroBlockEnd:   ''
+# MaxEmptyLinesToKeep: 1
+# NamespaceIndentation: None
+# ObjCBlockIndentWidth: 2
+# ObjCSpaceAfterProperty: false
+# ObjCSpaceBeforeProtocolList: true
+# PenaltyBreakBeforeFirstCallParameter: 19
+# PenaltyBreakComment: 300
+# PenaltyBreakFirstLessLess: 120
+# PenaltyBreakString: 1000
+# PenaltyExcessCharacter: 1000000
+# PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+# ReflowComments:  true
+SortIncludes:    false
+# SpaceAfterCStyleCast: false
+# SpaceAfterTemplateKeyword: true
+# SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+# SpaceInEmptyParentheses: false
+# SpacesBeforeTrailingComments: 1
+# SpacesInAngles:  false
+# SpacesInContainerLiterals: true
+# SpacesInCStyleCastParentheses: false
+# SpacesInParentheses: false
+# SpacesInSquareBrackets: false
+Standard: Cpp03
+TabWidth:        4
+UseTab:          Never


### PR DESCRIPTION
## What
Adds a `.clang-format` file to ceracoder using LLVM style, consistent with the other repos in the CeraLive stack (srt, srtla, irl-srt-server, gstlibuvch264src all use the same baseline).

## Why
Enforces consistent C formatting across the codebase. Editors and CI can now auto-format without style drift.

## How to verify
```bash
clang-format --dry-run --Werror src/*.c
```
No formatting errors on existing source.

## Risks
None — config file only, no source changes.